### PR TITLE
docs: expose desktop install guide

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -7,6 +7,7 @@ Practical how-to guides for developing, deploying, and extending OpenSail.
 | Guide | Description | When to Use |
 |-------|-------------|-------------|
 | [Docker Setup](docker-setup.md) | Set up OpenSail from scratch with Docker Compose | **Start here**. First-time setup, new developers |
+| [Desktop Install](desktop-install.md) | Install the desktop app or run the desktop client from source | Local-first use, desktop packaging, installer testing |
 | [Local Development](local-development.md) | Run backend/frontend natively (without Docker) | Faster iteration, debugging |
 | [Minikube Setup](minikube-setup.md) | Deploy to local Kubernetes cluster | Testing K8s features locally |
 | [AWS Deployment](aws-deployment.md) | Deploy to AWS EKS production | Production deployment |

--- a/docs/guides/desktop-install.md
+++ b/docs/guides/desktop-install.md
@@ -42,13 +42,15 @@ Common to all platforms:
 ## 3. Install from release
 
 Direct downloads live at
-[github.com/TesslateAI/opensail/releases](https://github.com/TesslateAI/opensail/releases).
-Pick the latest tagged release and grab the artifact for your OS.
+[github.com/TesslateAI/opensail/releases](https://github.com/TesslateAI/opensail/releases)
+when a desktop release includes installer assets. If the latest release has no
+desktop installer attached yet, use the build-from-source flow below.
 
 ### macOS (`.dmg`)
 
 1. Download `OpenSail_<version>_aarch64.dmg` (Apple Silicon) or
-   `OpenSail_<version>_x64.dmg` (Intel).
+   `OpenSail_<version>_x64.dmg` (Intel) when those assets are attached to the
+   release.
 2. Open the DMG and drag `OpenSail.app` into `/Applications`.
 3. First launch: right-click the app, pick "Open", then "Open" again at the
    Gatekeeper prompt. Shipped builds are codesigned with a Developer ID and
@@ -56,7 +58,7 @@ Pick the latest tagged release and grab the artifact for your OS.
 
 ### Windows (`.msi`)
 
-1. Download `OpenSail_<version>_x64_en-US.msi`.
+1. Download `OpenSail_<version>_x64_en-US.msi` when it is attached to the release.
 2. Double-click and step through the installer. It installs to
    `%LOCALAPPDATA%\Programs\OpenSail` by default and pins a Start menu entry.
 3. If SmartScreen flags the installer as "unrecognized", click "More info"


### PR DESCRIPTION
Fixes #113.

## What changed
- Adds `docs/guides/desktop-install.md` to the Guides index so the hosted docs graph can expose the desktop install page instead of leaving the linked route undiscoverable/404.
- Updates the desktop release section so it does not imply installers are always attached to the latest GitHub release. If no desktop assets are attached, the page now points users to the build-from-source flow.

## Checks
- Verified the live broken docs route returns `404`: `https://docs.tesslate.com/guides/desktop-install`
- Verified `docs/guides/desktop-install.md` exists in this repo.
- Verified current latest GitHub release has no assets attached.
- `git diff --check`

If this saves you time and you want to send a small thank-you for the direct docs fix, my link is https://buymeacoffee.com/nicdunz.