### PR TITLE
feat: add Requesty as an OpenAI-compatible LLM provider

### DIFF
--- a/app/src/components/chat/ModelSelector.tsx
+++ b/app/src/components/chat/ModelSelector.tsx
@@ -56,6 +56,7 @@ function getProviderLabel(provider: string, providerName?: string): string {
     deepseek: 'DeepSeek',
     fireworks: 'Fireworks',
     openrouter: 'OpenRouter',
+    requesty: 'Requesty',
     'nano-gpt': 'NanoGPT',
   };
   return labels[provider] || provider.charAt(0).toUpperCase() + provider.slice(1);

--- a/app/src/components/models/providers.ts
+++ b/app/src/components/models/providers.ts
@@ -67,6 +67,12 @@ const OPENROUTER_ICON = dataUri(
     '</svg>'
 );
 
+const REQUESTY_ICON = dataUri(
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black">' +
+    '<path d="M4 4h9a5 5 0 0 1 2 9.58L19 20h-3l-3.5-6H8v6H4zm4 3v4h5a2 2 0 0 0 0-4z"/>' +
+    '</svg>'
+);
+
 const NANOGPT_ICON = dataUri(
   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black">' +
     '<path d="M5 4h3l8 11V4h3v16h-3L8 9v11H5z"/>' +
@@ -113,6 +119,13 @@ export const PROVIDER_META: ProviderMeta[] = [
     brandColor: '#6467f2',
     iconUrl: OPENROUTER_ICON,
     website: 'https://openrouter.ai/keys',
+  },
+  {
+    key: 'requesty',
+    name: 'Requesty',
+    brandColor: '#6366f1',
+    iconUrl: REQUESTY_ICON,
+    website: 'https://app.requesty.ai/api-keys',
   },
   {
     key: 'groq',

--- a/orchestrator/app/services/model_adapters.py
+++ b/orchestrator/app/services/model_adapters.py
@@ -36,6 +36,7 @@ BYOK_PROVIDER_ENV_VARS: dict[str, str] = {
     "openai": "OPENAI_API_KEY",
     "anthropic": "ANTHROPIC_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
+    "requesty": "REQUESTY_API_KEY",
     "groq": "GROQ_API_KEY",
     "together": "TOGETHER_API_KEY",
     "deepseek": "DEEPSEEK_API_KEY",
@@ -98,6 +99,15 @@ BUILTIN_PROVIDERS: dict[str, dict[str, Any]] = {
         "api_type": "openai",
         "default_headers": {"HTTP-Referer": "https://tesslate.com", "X-Title": "OpenSail"},
         "website": "https://openrouter.ai",
+        "requires_key": True,
+    },
+    "requesty": {
+        "name": "Requesty",
+        "description": "Access to 300+ AI models through a unified OpenAI-compatible API",
+        "base_url": "https://router.requesty.ai/v1",
+        "api_type": "openai",
+        "default_headers": {"HTTP-Referer": "https://tesslate.com", "X-Title": "OpenSail"},
+        "website": "https://requesty.ai",
         "requires_key": True,
     },
     "nano-gpt": {


### PR DESCRIPTION
## Add Requesty as an OpenAI-compatible LLM provider

This PR adds [Requesty](https://requesty.ai) as a native BYOK provider, mirroring the existing OpenRouter provider as closely as possible. Requesty is an OpenAI-compatible LLM gateway, so it slots into the existing OpenAI-API routing path with no new adapter type.

### Wiring sites (mirrors OpenRouter exactly)

**Orchestrator (`orchestrator/app/services/model_adapters.py`)**
- `BYOK_PROVIDER_ENV_VARS`: added `"requesty": "REQUESTY_API_KEY"`.
- `BUILTIN_PROVIDERS`: added a `requesty` entry with `base_url: https://router.requesty.ai/v1`, `api_type: "openai"`, `requires_key: True`, and `website: https://requesty.ai`.

Because the orchestrator derives provider resolution (`resolve_model_name`, `extract_provider_slug`, model-id prefixing in `marketplace.py`, the public providers list, secrets/BYOK key storage, etc.) entirely from `BUILTIN_PROVIDERS` + `BYOK_PROVIDER_ENV_VARS`, this single config addition makes `requesty` a valid provider everywhere `openrouter` is. Model ids use the same `provider/model` convention, e.g. `requesty/openai/gpt-4o-mini` resolves to base `https://router.requesty.ai/v1` with model `openai/gpt-4o-mini`.

**Frontend**
- `app/src/components/models/providers.ts`: added a `requesty` `ProviderMeta` entry (with a single-color silhouette icon and `website: https://app.requesty.ai/api-keys`), mirroring the OpenRouter entry's field shape.
- `app/src/components/chat/ModelSelector.tsx`: added `requesty: 'Requesty'` to the provider label map.

The default provider is unchanged; `requesty` is simply offered as an additional option.

### Verification

- **Frontend typecheck:** `pnpm install --frozen-lockfile` + `pnpm run typecheck` (`tsc -b --noEmit`) in `app/` — passes with no errors.
- **Python syntax:** `ast.parse` on the edited `model_adapters.py` and `marketplace.py` — OK.
- **Orchestrator tests:** `pytest tests/agent/test_model_adapter_dbless.py` — 31 passed. This suite exercises the exact `BYOK_PROVIDER_ENV_VARS` / `create_model_adapter` path that resolves the new provider.
- **Resolver check:** `create_model_adapter("requesty/openai/gpt-4o-mini", db=None)` returns an `OpenAIAdapter` with `base_url = https://router.requesty.ai/v1` and `model_name = openai/gpt-4o-mini`.
- **Live chat completion:** issued a real request to `https://router.requesty.ai/v1/chat/completions` with `model: openai/gpt-4o-mini`, `max_tokens: 16` — returned HTTP 200 and a valid completion (`gpt-4o-mini-2024-07-18`).

### Links
- https://requesty.ai
- https://docs.requesty.ai

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
